### PR TITLE
Filter erroneous CO2 readings

### DIFF
--- a/snuffel.ino
+++ b/snuffel.ino
@@ -120,12 +120,14 @@ void setup_sensors() {
             init: []() {
                 hwserial.begin(9600, SERIAL_8N1, rx, tx);
                 mhz.begin(hwserial);
+                mhz.setFilter(true, true); // Filter out erroneous readings (set to 0)
                 mhz.autoCalibration();
             },
             prepare: NULL,
             fetch: [](SnuffelSensor& self) {
                 int CO2 = mhz.getCO2();
-                self.publish(String(CO2), "PPM");
+                if (CO2)
+                    self.publish(String(CO2), "PPM");
             }
         };
         snuffels.push_back(s);


### PR DESCRIPTION
This uses the MHZ19 library filter function in mode 1, where erroneous readings are set to 0.

Mode 2 would be more elegant as this gives an error code instead, but that seems to be broken.

Reference: https://github.com/WifWaf/MH-Z19/blob/master/examples/FilterUsage/FilterUsage.ino