### PR TITLE
Add support for SenseAir S8 CO2 sensor

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -31,6 +31,7 @@ lib_deps =
     Adafruit BME280 Library
     NeoPixelBus
     https://github.com/sparkfun/SparkFun_HTU21D_Breakout_Arduino_Library
+    S8_UART
 
 [env:serial]
 upload_protocol = esptool


### PR DESCRIPTION
Turns out SenseAir S8 LP sensors are pin compatible with the MH-Z19b modules, and will fit on the Snuffelaar PCB without any mods!