### PR TITLE
Replace HTU21D library

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -30,7 +30,7 @@ lib_deps =
     MH-Z19
     Adafruit BME280 Library
     NeoPixelBus
-    https://github.com/sparkfun/SparkFun_HTU21D_Breakout_Arduino_Library
+    HTU21D Sensor Library
     S8_UART
 
 [env:serial]


### PR DESCRIPTION
New one is not deprecated, and fixes I2C errors on the ESP32.