### PR TITLE
disable brownout detection, and set AQC-0-0-0 sensor as non-default in config.

### DIFF
--- a/snuffelding.ino
+++ b/snuffelding.ino
@@ -159,7 +159,7 @@ void setup_sensors() {
         static int alarm_level;
 
         struct SnuffelSensor s = {
-            enabled: true,
+            enabled: false,
             id: "AQC-0-0-0-0",
             description: "CO2 sensor",
             topic_suffix: "co2",

--- a/snuffelding.ino
+++ b/snuffelding.ino
@@ -16,6 +16,8 @@
 #include <ArduinoOTA.h>
 #include <math.h>
 #include <list>
+#include <soc/soc.h>
+#include <soc/rtc_cntl_reg.h>
 using namespace std;
 
 unsigned long interval;
@@ -465,6 +467,7 @@ void check_button() {
 }
 
 void setup() {
+    WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 0);
     Serial.begin(115200);
     SPIFFS.begin(true);
     Wire.begin(i2c_sda, i2c_scl);


### PR DESCRIPTION
In some cases brownout detection gets triggered, when it serves no purpose to do so. This change disables that check.

During initial setup, 2 CO² sensors are set as enabled, this change disables AQC-0-0-0 as default, leaving only MH-Z19. (can still be changed in the webconfig)